### PR TITLE
Fix typo in wp-source.md

### DIFF
--- a/docs-api/frontity-packages/features-packages/wp-source.md
+++ b/docs-api/frontity-packages/features-packages/wp-source.md
@@ -647,7 +647,7 @@ Entities are normally never overwritten. So, if an entity already exists in the 
 
 ```javascript
 const response = await libraries.source.api.get({ endpoint: "posts" })
-const entitiesAdded = await libraries.source.populate({ response, state }))
+const entitiesAdded = await libraries.source.populate({ response, state })
 
 entitiesAdded.forEach(({type, id, link}) => {
   console.log({type, id, link})


### PR DESCRIPTION
There  is more closing brackets, as opening in line 650: 
`const entitiesAdded = await libraries.source.populate({ response, state }))`