### PR TITLE
Adds info about the 'link' processor to components.md

### DIFF
--- a/docs-api/frontity-packages/collections-packages/components.md
+++ b/docs-api/frontity-packages/collections-packages/components.md
@@ -144,6 +144,38 @@ const Link = ({
 export default connect(Link);
 ```
 
+#### The `link` processor
+
+Frontity provides a `link` processor. The `link` processor works with the `<html2react>` component and can automatically detect `<a>` tags in the page/post content and intelligently convert them into `<Link>` components.
+
+If the `href` attribute of the `<a>` tag is either:
+
+- a relative link, or
+- an absolute link on the same domain as the WordPress data source
+
+then the processor will convert the the `<a>` tag into a `<Link>` component.
+
+The `<Link>` component created by the processor will be modelled on the `<a>` tag and will have properties consistent with it's attributes - e.g. the `link` property of the `<Link>` component will be the same as the `href` attribute of `<a>` tag being replaced. The processor will also convert absolute links on the same domain to be relative links.
+
+If the `href` attribute of the `<a>` tag is an absolute link on a different domain from the WordPress data source, i.e. it is a link to an external site, then that tag will remain as is and will not be replaced or converted.
+
+In order for this to work two conditions must be met:
+
+1. The WordPress data source must be defined using `state.source.url`, it will not work if the data source is defined with the (now deprecated) `state.source.api`. See [here](https://api.frontity.org/frontity-packages/features-packages/wp-source#rest-api-settings) and [here](https://docs.frontity.org/guides/setting-url-wordpress-source-data) for more information on defining your data source URL.
+
+2. The `link` processor must be imported into the theme and included in the list of `html2react` processors. This would normally be done in the root level `index.js` of your theme. See [here](../features-packages/html2reeact.md) and [here](https://docs.frontity.org/learning-frontity/libraries#array-of-processors-from-html-2-react) for more info.
+
+```js
+import link from "@frontity/html2react/processors/link";
+```
+
+```js
+libraries: {
+  html2react: {
+    processors: [link],
+  },
+```
+
 ### Image
 
 `<Image />` is a React component that adds `lazy-loading` to the native WordPress images. Combined with [`@html2react/processors`](frontity-html2react.md#processors) , you can add this functionality and optimize your images pretty easy.

--- a/docs-api/frontity-packages/collections-packages/components.md
+++ b/docs-api/frontity-packages/collections-packages/components.md
@@ -160,11 +160,7 @@ The `<Link>` component created by the processor will be modelled on the `<a>` ta
 
 If the `href` attribute of the `<a>` tag is an absolute link on a different domain from the WordPress data source, i.e. it is a link to an external site, then that tag will remain as is and will not be replaced or converted.
 
-In order for this to work two conditions must be met:
-
-1. The WordPress data source must be defined using `state.source.url`, it will not work if the data source is defined with the (now deprecated) `state.source.api`. See [here](https://api.frontity.org/frontity-packages/features-packages/wp-source#rest-api-settings) and [here](https://docs.frontity.org/guides/setting-url-wordpress-source-data) for more information on defining your data source URL.
-
-2. The `link` processor must be imported into the theme and included in the list of `html2react` processors. This would normally be done in the root level `index.js` of your theme. See [here](../features-packages/html2reeact.md) and [here](https://docs.frontity.org/learning-frontity/libraries#array-of-processors-from-html-2-react) for more info.
+In order for this to work the `link` processor must be imported into the theme and included in the list of `html2react` processors. This would normally be done in the root level `index.js` of your theme. See [here](../features-packages/html2reeact.md) and [here](https://docs.frontity.org/learning-frontity/libraries#array-of-processors-from-html-2-react) for more info.
 
 ```js
 import link from "@frontity/html2react/processors/link";

--- a/docs-api/frontity-packages/collections-packages/components.md
+++ b/docs-api/frontity-packages/collections-packages/components.md
@@ -16,7 +16,7 @@ This package is a collection of React components that have proven to be pretty u
     - [Props](#props)
     - [Usage](#usage)
     - [Auto Prefetch](#auto-prefetch)
-    - [Custom `` component](#custom-component)
+    - [Custom `Link` component](#custom-link-component)
     - [The `link` processor](#the-link-processor)
   - [Image](#image)
   - [Script](#script)
@@ -100,7 +100,7 @@ The possible values for `state.theme.autoPrefetch` are:
 | `in-view` | Prefetch links currently visible in the viewport. |
 | `all`     | Prefetches all internal links on the page.        |
 
-#### Custom `<Link />` component
+#### Custom `Link` component
 
 Using this `<Link />` component is optional. You can create your own `<Link />` component with your own logic.
 

--- a/docs-api/frontity-packages/collections-packages/components.md
+++ b/docs-api/frontity-packages/collections-packages/components.md
@@ -17,6 +17,7 @@ This package is a collection of React components that have proven to be pretty u
     - [Usage](#usage)
     - [Auto Prefetch](#auto-prefetch)
     - [Custom `` component](#custom-component)
+    - [The `link` processor](#the-link-processor)
   - [Image](#image)
   - [Script](#script)
     - [Props](#props)

--- a/docs-api/frontity-packages/collections-packages/components.md
+++ b/docs-api/frontity-packages/collections-packages/components.md
@@ -156,7 +156,7 @@ If the `href` attribute of the `<a>` tag is either:
 
 then the processor will convert the the `<a>` tag into a `<Link>` component.
 
-The `<Link>` component created by the processor will be modelled on the `<a>` tag and will have properties consistent with it's attributes - e.g. the `link` property of the `<Link>` component will be the same as the `href` attribute of `<a>` tag being replaced. The processor will also convert absolute links on the same domain to be relative links.
+The `<Link>` component created by the processor will be modelled on the `<a>` tag and will have properties consistent with its attributes - e.g. the `link` property of the `<Link>` component will be the same as the `href` attribute of `<a>` tag being replaced. The processor will also convert absolute links on the same domain to be relative links.
 
 If the `href` attribute of the `<a>` tag is an absolute link on a different domain from the WordPress data source, i.e. it is a link to an external site, then that tag will remain as is and will not be replaced or converted.
 


### PR DESCRIPTION
Adds new section under the `Link` component documentation entitled "The `link` processor".

As per https://github.com/frontity/api-reference/issues/17