### PR TITLE
Adds note on state.source.url to wp-source.md

### DIFF
--- a/docs-api/frontity-packages/features-packages/wp-source.md
+++ b/docs-api/frontity-packages/features-packages/wp-source.md
@@ -110,6 +110,10 @@ export default {
 };
 ```
 
+{% hint style="info" %}
+If you are using [Embedded Mode](https://docs.frontity.org/architecture/embedded-mode) for your Frontity project, you do not normally have to set the `state.source.url` property as it will be the same as the `state.frontity.url` property.
+{% endhint %}
+
 #### `state.source.api`
 
 The URL of your WordPress REST API endpoint.

--- a/docs-api/frontity-packages/features-packages/wp-source.md
+++ b/docs-api/frontity-packages/features-packages/wp-source.md
@@ -111,7 +111,7 @@ export default {
 ```
 
 {% hint style="info" %}
-If you are using [Embedded Mode](https://docs.frontity.org/architecture/embedded-mode) for your Frontity project, you do not normally have to set the `state.source.url` property as it will be the same as the `state.frontity.url` property.
+If you are using [Embedded Mode](https://docs.frontity.org/architecture/embedded-mode) for your Frontity project, and the `state.frontity.url` property is set, you do not have to also set the `state.source.url` property as this will be the same as the value in the `state.frontity.url` property.
 {% endhint %}
 
 #### `state.source.api`


### PR DESCRIPTION
Adds the following note to features-packages/wp-source.md → Settings → REST API settings → `state.source.url`:

> If you are using [Embedded Mode](https://docs.frontity.org/architecture/embedded-mode) for your Frontity project, you do not normally have to set the `state.source.url` property as it will be the same as the `state.frontity.url` property.