### PR TITLE
Removed 'community' sentence in WordPress Plugins section

### DIFF
--- a/docs-api/frontity-plugins/README.md
+++ b/docs-api/frontity-plugins/README.md
@@ -1,10 +1,9 @@
 # 🔌 WordPress Plugins
 
-In order to get the most of Headless WordPress, sometime we'll want to add functionality to the backend. Most of the Frontity plugins will extend the REST API so it makes easier to connect the frontend.
+In order to get the most out of Headless WordPress, sometime we'll want to add functionality to the backend. Most of the Frontity plugins will extend the REST API so it makes easier to connect the frontend.
 
 This is the list of the current plugins:
 
 {% page-ref page="rest-api-head-tags.md" %}
 {% page-ref page="embedded-mode.md" %}
 
-Do you have a new idea, feel free to suggest it at [our community](https://community.frontity.org/).


### PR DESCRIPTION
I've suggested removing the last sentence as the other main sections don't have any mention about the community, so they are all consistent. Maybe the description could be improved as well, I especially found this sentence "Most of the Frontity plugins will extend the REST API so it makes easier to connect the frontend" a bit confusing.