### PR TITLE
Removed community hint in @frontity/tiny-router page

### DIFF
--- a/docs-api/frontity-packages/features-packages/tiny-router.md
+++ b/docs-api/frontity-packages/features-packages/tiny-router.md
@@ -125,6 +125,3 @@ These are some examples of links:
 
 This is the object that was saved in [`window.history.state`](https://developer.mozilla.org/en-US/docs/Web/API/History/state) when the route was changed.
 
-{% hint style="info" %}
-Still have questions? Ask [the community](https://community.frontity.org/)! We are here to help 😊
-{% endhint %}


### PR DESCRIPTION
I've suggested removing this hint so all pages are consistent. I think this was the last one remaining.