### PR TITLE
Adding a more precise example of how to use transformLinks

### DIFF
--- a/docs-api/frontity-packages/features-packages/yoast.md
+++ b/docs-api/frontity-packages/features-packages/yoast.md
@@ -77,8 +77,15 @@ Example:
 
 ```javascript
 {
-  ignore: "^(wp-(json|admin|content|includes))|feed|comments|xmlrpc",
-  base: "https://wp.mysite.com"
+  name: "@frontity/yoast",
+  state: {
+    yoast: {
+      transformLinks: {
+        ignore: "^(wp-(json|admin|content|includes))|feed|comments|xmlrpc",
+        base: "https://wp.mysite.com",
+      },
+    },
+  },
 }
 ```
 


### PR DESCRIPTION
The example of how to use the `trasnformLinks` feature was a bit confusing. I had to look at the hook in the package `@frontity/yoast`  to actually figure out how it works. I think this small adjustment in the example will make it more clear how to use it.